### PR TITLE
Fix asset paths in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
 <title>Alpha AI Color Lab by Sony</title>
 
 <!-- PWA and Add to Home Screen Configuration -->
-<link rel="icon" type="image/png" href="/assets/Logo.png">
-<link rel="apple-touch-icon" href="/assets/Logo.png">
+<link rel="icon" type="image/png" href="/src/assets/Logo.png">
+<link rel="apple-touch-icon" href="/src/assets/Logo.png">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="white">
 <meta name="apple-mobile-web-app-title" content="ColorLAB">
 <meta name="theme-color" content="#ffffff">
-<link rel="manifest" href="data:application/manifest+json;charset=utf-8,{%22name%22:%22Alpha%20AI%20Color%20Lab%22,%22short_name%22:%22ColorLAB%22,%22start_url%22:%22.%22,%22display%22:%22standalone%22,%22background_color%22:%22%23F7F7F7%22,%22theme_color%22:%22%23ffffff%22,%22icons%22:[{%22src%22:%22/assets/logo_black.png%22,%22sizes%22:%22192x192%22,%22type%22:%22image/png%22},{%22src%22:%22/assets/logo_black.png%22,%22sizes%22:%22512x512%22,%22type%22:%22image/png%22}]}">
+<link rel="manifest" href="data:application/manifest+json;charset=utf-8,{%22name%22:%22Alpha%20AI%20Color%20Lab%22,%22short_name%22:%22ColorLAB%22,%22start_url%22:%22.%22,%22display%22:%22standalone%22,%22background_color%22:%22%23F7F7F7%22,%22theme_color%22:%22%23ffffff%22,%22icons%22:[{%22src%22:%22/src/assets/logo_black.png%22,%22sizes%22:%22192x192%22,%22type%22:%22image/png%22},{%22src%22:%22/src/assets/logo_black.png%22,%22sizes%22:%22512x512%22,%22type%22:%22image/png%22}]}">
 
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://d3js.org/d3.v7.min.js" defer></script>
@@ -39,7 +39,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div id="appContainer" class="min-h-screen w-screen p-3 sm:p-4 md:p-6 flex flex-col">
     <header class="flex justify-between items-center w-full z-20 flex-shrink-0">
         <button id="homeBtn" class="flex items-center transition-transform duration-200 hover:scale-105 active:scale-100">
-			<img src="/assets/logo_black.png" alt="Alpha AI Color Lab Logo" class="h-16 md:h-20 w-auto">
+			<img src="/src/assets/logo_black.png" alt="Alpha AI Color Lab Logo" class="h-16 md:h-20 w-auto">
 		</button>
         <div class="flex items-center gap-2 md:gap-4">
             <nav id="mainNav" class="hidden md:flex items-center gap-4">


### PR DESCRIPTION
The logo and other assets were not displaying because the paths in `index.html` were incorrect. The assets are located in the `src/assets` directory, but the paths were absolute from the root (e.g., `/assets/Logo.png`).

This commit prepends `/src` to the asset paths in `index.html` to correctly reference them, which is the standard way to handle assets in `src` with Vite when referenced from `index.html`.